### PR TITLE
refactor: update patchProps method to pass all props not only iterable ones

### DIFF
--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -7,6 +7,7 @@ index_html_content="<!DOCTYPE html>
   <head>
     <meta charset=\"utf-8\" />
     <meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\" />
+    <title>million - demo</title>
     <link rel=\"stylesheet\" href=\"./style.css\">
     <script type=\"module\" src=\"./script.tsx\"></script>
   </head>
@@ -20,7 +21,10 @@ const App = (text: string) => {
 
 const app = createElement(App('Hello World'));
 document.body.appendChild(app);
-patch(app, App('Goodbye World'));
+
+setTimeout(() => {
+  patch(app, App('Goodbye World'));
+}, 1000);
 "
 style_css_content="body {
   font-size: 2em;

--- a/src/__test__/patch.spec.ts
+++ b/src/__test__/patch.spec.ts
@@ -49,6 +49,24 @@ describe('.patch', () => {
     expect(el.title).toEqual('');
   });
 
+  it('should keep old props and add new ones', () => {
+    const el = document.createElement('div');
+    el.id = 'app';
+
+    patchProps(<HTMLElement>el, { id: 'app' }, { title: 'bar', id: 'app' });
+
+    expect(el.id).toEqual('app');
+    expect(el.title).toEqual('bar');
+
+    patchProps(<HTMLElement>el, { title: 'bar', id: 'app', lang: 'pt', spellcheck: false }, { title: 'foo', id: '', lang: '', hidden: true});
+
+    expect(el.id).toEqual('app'); // keeped
+    expect(el.lang).toEqual('pt'); // keeped
+    expect(el.title).toEqual('foo'); // updated
+    expect(el.hidden).toEqual(true);  // setted
+    expect(el.spellcheck).toBeFalsy(); // removed
+  });
+
   it('should patch children', () => {
     const virtualArrayToDOMNodes = (children: (string | VNode)[]): (HTMLElement | Text)[] =>
       children.map((child: string | VNode) => createElement(child));

--- a/src/patch.ts
+++ b/src/patch.ts
@@ -9,14 +9,12 @@ import { VElement, VNode, VProps } from './m';
  * @param {VProps} newProps - New VNode props
  */
 export const patchProps = (el: HTMLElement, oldProps: VProps = {}, newProps: VProps = {}): void => {
-  if (!oldProps && !newProps) return;
-
   const oldPropKeys = Object.keys(oldProps);
   const newPropKeys = Object.keys(newProps);
 
   if ((newProps && !oldProps) || oldPropKeys.length > newPropKeys.length) {
     // Deletion has occured
-    for (const propName of oldPropKeys) {
+    [...oldPropKeys].forEach((propName) => {
       const newPropValue = newProps[propName];
       /* istanbul ignore if */
       if (newPropValue) {
@@ -25,17 +23,17 @@ export const patchProps = (el: HTMLElement, oldProps: VProps = {}, newProps: VPr
       }
       delete el[propName];
       el.removeAttribute(propName);
-    }
+    })
   } else {
     // Addition/No change/Content modification has occured
-    for (const propName of newPropKeys) {
+    [...newPropKeys].forEach((propName) => {
       const oldPropValue = oldProps[propName];
-      if (oldPropValue) {
-        if (oldPropValue !== oldProps[propName]) el[propName] = newProps[propName];
+      if (oldPropValue && !newProps[propName]) {
+        el[propName] = oldPropValue;
         return;
       }
       el[propName] = newProps[propName];
-    }
+    })
   }
 };
 


### PR DESCRIPTION
**Description:**
We currently are only iterate through the iterable props but we should iterate over all props...

**Status**

- [x] Code changes have been tested against prettier, or there are no code changes

**Semantic versioning classification:**

- [x] This PR changes the codebase
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
  - [x] This PR changes the internal workings with no modifications to the external API (bug fixes, performance improvements)
