### PR TITLE
Improvements in tests and readability of createElement fn

### DIFF
--- a/src/__test__/createElement.spec.ts
+++ b/src/__test__/createElement.spec.ts
@@ -3,6 +3,8 @@ import { OLD_VNODE_FIELD } from '../constants';
 import { m } from '../m';
 import { VNode, VProps } from '../structs';
 
+const createManual = (tag: string, props: unknown) => Object.assign(document.createElement(tag), props);
+
 const h = (tag: string, props?: VProps, ...children: VNode[]) =>
   m(
     tag,
@@ -19,9 +21,7 @@ describe('.createElement', () => {
     expect(createElement(h('div'))).toEqual(document.createElement('div') as HTMLElement);
 
     const created = createElement(h('div', { id: 'app' }, 'foo'));
-    const manual = document.createElement('div') as HTMLElement;
-    manual.id = 'app';
-    manual.innerHTML = 'foo';
+    const manual = createManual('div', { id: 'app', innerHTML: 'foo' }) as HTMLElement;
 
     expect(created).toEqual(manual);
   });
@@ -30,11 +30,20 @@ describe('.createElement', () => {
     expect(createElement(h('div'))).toEqual(<HTMLElement>document.createElement('div'));
 
     const created = createElement(h('div', { id: 'app' }, 'foo'));
-    const manual = <HTMLElement>document.createElement('div');
-    manual.id = 'app';
-    manual.innerHTML = 'foo';
+    const manual = <HTMLElement>createManual('div', { id: 'app', innerHTML: 'foo' });
 
     expect(created).toEqual(manual);
+  });
+
+  it('should create HTMLElement from vnode with VNode child', () => {
+    const child = h('section', { id: 'child' }, 'bar');
+    const created = createElement(h('div', { id: 'app' }, child));
+
+    const mCreated = <HTMLElement>createManual('div', { id: 'app' });
+    const mChild = <HTMLElement>createManual('section', { id: 'child', innerHTML: 'bar' });
+
+    mCreated.append(mChild);
+    expect(created).toEqual(mCreated);
   });
 
   it('should create HTMLElement from vnode', () => {

--- a/src/createElement.ts
+++ b/src/createElement.ts
@@ -9,19 +9,11 @@ import { VNode } from './structs';
  */
 export const createElement = (vnode: VNode, attachField = true): HTMLElement | Text => {
   if (typeof vnode === 'string') return document.createTextNode(vnode);
-  const el = document.createElement(vnode.tag);
+  const el = Object.assign(document.createElement(vnode.tag), vnode.props);
 
-  if (vnode.props) {
-    for (const name of Object.keys(vnode.props)) {
-      el[name] = vnode.props[name];
-    }
-  }
-
-  if (vnode.children) {
-    for (let i = 0; i < vnode.children.length; ++i) {
-      el.appendChild(createElement(vnode.children[i]));
-    }
-  }
+  vnode.children && vnode.children.forEach(child => {
+    el.appendChild(createElement(child));
+  });
 
   if (attachField) el[OLD_VNODE_FIELD] = vnode;
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR makes some simple improvements for createElement function/tests by increasing readability and turning the function smaller. Also apply some DRY rules to __test__/createElement.

A small performance (time complexity) improvement can be considered since there is only a single call to create an element instead many attributions, also a forEach loop has downsized the needing of some allocations downing the space complexity, but I think these points are tiny and almost imperceptible.

Obs: i didnt created a new build since i dont know if i should do it (?).

**Status**

- [ ] Code changes have been tested against prettier, or there are no code changes
- [ x ] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ x ] This PR changes the codebase
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
  - [ x ] This PR changes the internal workings with no modifications to the external API (bug fixes, performance improvements)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
