### PR TITLE
use cache `Set()` for performance improvement

### DIFF
--- a/src/patch.ts
+++ b/src/patch.ts
@@ -10,12 +10,12 @@ import { VActions, VElement, VFlags, VNode, VProps } from './structs';
  */
 /* istanbul ignore next */
 export const patchProps = (el: HTMLElement, oldProps: VProps, newProps: VProps): void => {
-  const cache = [];
+  const cache = new Set<string>();
   for (const oldPropName of Object.keys(oldProps)) {
     const newPropValue = newProps[oldPropName];
     if (newPropValue) {
       el[oldPropName] = newPropValue;
-      cache.push(oldPropName);
+      cache.add(oldPropName);
     } else {
       el.removeAttribute(oldPropName);
       delete el[oldPropName];
@@ -23,7 +23,7 @@ export const patchProps = (el: HTMLElement, oldProps: VProps, newProps: VProps):
   }
 
   for (const newPropName of Object.keys(newProps)) {
-    if (!cache.includes(newPropName)) {
+    if (!cache.has(newPropName)) {
       el[newPropName] = newProps[newPropName];
     }
   }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Use Set instead of Array for cache object 

**Status**

- [x] Code changes have been tested against prettier, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [x] This PR changes the codebase
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
  - [x] This PR changes the internal workings with no modifications to the external API (bug fixes, performance improvements)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.

Before:
```
list-render:
million x 19,445 ops/sec ±8.47% (16 runs sampled)
virtual-dom x 17,862 ops/sec ±11.48% (44 runs sampled)
vanilla x 8,620 ops/sec ±0.69% (48 runs sampled)
baseline x 14,730 ops/sec ±0.53% (14 runs sampled)
Fastest is million
```

After: 
```
list-render:
million x 28,808 ops/sec ±5.67% (30 runs sampled)
virtual-dom x 19,361 ops/sec ±1.45% (49 runs sampled)
vanilla x 8,621 ops/sec ±0.71% (48 runs sampled)
baseline x 14,591 ops/sec ±0.78% (13 runs sampled)
Fastest is million
```


